### PR TITLE
Update Gemfile.lock to support ruby 2.7

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -30,6 +30,7 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
       - run: bundle exec rubocop
+      - run: bundle exec bundle-audit
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby-version: ["3.0", "3.1", "3.2"]
+        ruby-version: ["2.7", "3.0", "3.1", "3.2"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,9 @@ GEM
   specs:
     ast (2.4.2)
     base64 (0.1.1)
+    bundler-audit (0.9.2)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dry-cli (1.0.0)
@@ -64,6 +67,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    thor (1.3.2)
     unicode-display_width (2.4.2)
 
 PLATFORMS
@@ -77,8 +81,12 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bundler-audit
   rspec
   rubocop
   rubocop-rspec
   simplecov
   tabled!
+
+BUNDLED WITH
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       dry-cli
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     ast (2.4.2)
     base64 (0.1.1)
@@ -24,7 +24,7 @@ GEM
     racc (1.7.1)
     rainbow (3.1.1)
     regexp_parser (2.8.1)
-    rexml (3.2.6)
+    rexml (3.3.8)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-22
   arm64-darwin-23
+  ruby
   x86_64-darwin-20
   x86_64-linux
 
@@ -81,6 +82,3 @@ DEPENDENCIES
   rubocop-rspec
   simplecov
   tabled!
-
-BUNDLED WITH
-   2.5.11

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ data = [
 Tabled.new(data, row_separator: nil).print_to_console
 ```
 
+### Print Ruby CSV records
+
+```ruby
+csv = CSV.parse(<<~ROWS, headers: true)
+  Bob,Engineering,1000
+  Jane,Sales,2000
+  John,Management,5000
+ROWS
+
+Tabled.from_csv(csv: csv, framed: true).print_to_console
+```
+
 ## Exporting Data
 
 You can export the data in CSV or JSON formats. By default, the file is saved in the current directory with the file name "tabled.csv" (CSV format).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   app:
     build:
       dockerfile_inline: |
-        FROM ruby:bullseye
+        FROM ruby:2.7-bullseye
         COPY Gemfile Gemfile.lock tabled.gemspec .
         RUN bundle install
     working_dir: /app

--- a/tabled.gemspec
+++ b/tabled.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
                     'rubygems_mfa_required' => 'true' }
   s.license = 'MIT'
 
+  s.required_ruby_version = '>= 2.7.0'
+
   s.add_dependency 'dry-cli' # For CLI ap
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'

--- a/tabled.gemspec
+++ b/tabled.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7.0'
 
   s.add_dependency 'dry-cli' # For CLI ap
+  s.add_development_dependency 'bundler-audit'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rubocop-rspec'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced testing environment for Ruby applications by including Ruby version 2.7 in the testing matrix.
	- Introduced a new environment variable for Bundler version.
	- Updated Dockerfile configuration to specify Ruby 2.7 as the base image for the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->